### PR TITLE
[IDP-1391] Validate and apply nullable on nested schema properties

### DIFF
--- a/src/Workleap.Extensions.OpenAPI/RequiredType/ExtractRequiredAttributeFromNullableType.cs
+++ b/src/Workleap.Extensions.OpenAPI/RequiredType/ExtractRequiredAttributeFromNullableType.cs
@@ -33,6 +33,7 @@ internal sealed class ExtractRequiredAttributeFromNullableType : ISchemaFilter
     // https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2758
     private static void PatchNonNullableReferenceTypesOnNestedSchema(OpenApiSchema schema, SchemaFilterContext context)
     {
+        // NullabilityInfoContext is used to analyze the nullability of properties. It uses reflection to inspect the type of the member and determine if it is nullable.
         var nullabilityInfoContext = new NullabilityInfoContext();
         var contextProperties = context.Type.GetProperties();
 

--- a/src/Workleap.Extensions.OpenAPI/RequiredType/ExtractRequiredAttributeFromNullableType.cs
+++ b/src/Workleap.Extensions.OpenAPI/RequiredType/ExtractRequiredAttributeFromNullableType.cs
@@ -51,7 +51,7 @@ internal sealed class ExtractRequiredAttributeFromNullableType : ISchemaFilter
                 continue;
             }
 
-            // If there is a mismatch between the OpenAPISchema nullability and the context reflected nullability, we defer to the context nullability.
+            // If there is a mismatch between the OpenApiSchema nullability and the context reflected nullability, we defer to the context nullability.
             var detectedNullability = property.Nullable;
             var reflectedNullability = nullabilityInfo.ReadState == NullabilityState.Nullable;
             if (detectedNullability != reflectedNullability)

--- a/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
@@ -8,7 +8,7 @@ namespace WebApi.OpenAPI.SystemTest.OperationId;
 public class RequiredTypeController : ControllerBase
 {
     [HttpGet("/recordClassRequiredType", Name = "GetRecordClassRequiredType")]
-    [ProducesResponseType(typeof(ParentRequiredExample.RequiredExample), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(RequiredExampleGrandParentRecord), StatusCodes.Status200OK)]
     public IActionResult RecordClassRequiredType()
     {
         return this.Ok();
@@ -22,37 +22,37 @@ public class RequiredTypeController : ControllerBase
     }
 }
 
-public sealed record ParentRequiredExample(string Id)
+public sealed record RequiredExampleGrandParentRecord(RequiredExampleGrandParentRecord.RequiredExampleParentRecord RequiredExampleParent, string? OptionalGrandParentProperty)
 {
-    public sealed record RequiredExample(IReadOnlyCollection<RequiredExample.Example> Examples, string? OptionalStringProperty)
+    public sealed record RequiredExampleParentRecord(IReadOnlyCollection<RequiredExampleParentRecord.RequiredExampleRecord> RequiredExamples, string? OptionalParentProperty)
     {
-        public sealed record Example(IReadOnlyCollection<Example.Result> Results, string Property)
+        public sealed record RequiredExampleRecord(IReadOnlyCollection<RequiredExampleRecord.ResultRecord> Results, string ExampleProperty)
         {
-            public sealed record Result(string Id, string? OptionalProperty);
+            public sealed record ResultRecord(string ResultId, string? OptionalResultProperty);
         }
     }
 }
 
-public sealed class RequiredExampleGrandParentClass(RequiredExampleParentClass requiredExampleParent, string? optionalStringProperty)
+public sealed class RequiredExampleGrandParentClass(RequiredExampleParentClass requiredExampleParent, string? optionalGrandParentProperty)
 {
     public RequiredExampleParentClass RequiredExampleParent { get; } = requiredExampleParent;
-    public string? OptionalStringProperty { get; } = optionalStringProperty;
+    public string? OptionalGrandParentProperty { get; } = optionalGrandParentProperty;
 }
 
-public sealed class RequiredExampleParentClass(IReadOnlyCollection<RequiredExampleClass> requiredExamples, string? optionalStringProperty)
+public sealed class RequiredExampleParentClass(IReadOnlyCollection<RequiredExampleClass> requiredExamples, string? optionalParentProperty)
 {
     public IReadOnlyCollection<RequiredExampleClass> RequiredExamples { get; } = requiredExamples;
-    public string? OptionalStringProperty { get; } = optionalStringProperty;
+    public string? OptionalParentProperty { get; } = optionalParentProperty;
 }
 
-public sealed class RequiredExampleClass(IReadOnlyCollection<ResultExampleClass> resultExamples, string property)
+public sealed class RequiredExampleClass(IReadOnlyCollection<ResultClass> results, string exampleProperty)
 {
-    public IReadOnlyCollection<ResultExampleClass> ResultExamples { get; } = resultExamples;
-    public string Property { get; } = property;
+    public IReadOnlyCollection<ResultClass> Results { get; } = results;
+    public string ExampleProperty { get; } = exampleProperty;
 }
 
-public sealed class ResultExampleClass(string id, string? optionalProperty)
+public sealed class ResultClass(string resultId, string? optionalResultProperty)
 {
-    public string Id { get; } = id;
-    public string? OptionalProperty { get; } = optionalProperty;
+    public string ResultId { get; } = resultId;
+    public string? OptionalResultProperty { get; } = optionalResultProperty;
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
@@ -41,13 +41,13 @@ public sealed class RequiredExampleGrandParentClass(RequiredExampleParentClass r
 
 public sealed class RequiredExampleParentClass(IReadOnlyCollection<RequiredExampleClass> requiredExamples, string? optionalStringProperty)
 {
-    public IReadOnlyCollection<RequiredExampleClass> Examples { get; } = requiredExamples;
+    public IReadOnlyCollection<RequiredExampleClass> RequiredExamples { get; } = requiredExamples;
     public string? OptionalStringProperty { get; } = optionalStringProperty;
 }
 
 public sealed class RequiredExampleClass(IReadOnlyCollection<ResultExampleClass> resultExamples, string property)
 {
-    public IReadOnlyCollection<ResultExampleClass> Results { get; } = resultExamples;
+    public IReadOnlyCollection<ResultExampleClass> ResultExamples { get; } = resultExamples;
     public string Property { get; } = property;
 }
 

--- a/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
@@ -8,11 +8,17 @@ namespace WebApi.OpenAPI.SystemTest.OperationId;
 public class RequiredTypeController : ControllerBase
 {
     [HttpGet("/recordClassRequiredType", Name = "GetRecordClassRequiredType")]
-    [ProducesResponseType(typeof(RequiredExample), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ParentRequiredExample.RequiredExample), StatusCodes.Status200OK)]
     public IActionResult RecordClassRequiredType()
     {
-        return this.Ok(new RequiredExample(0, "example", null, 0));
+        return this.Ok();
     }
 }
 
-public sealed record RequiredExample(int RequiredIntProperty, string RequiredStringProperty, string? OptionalStringProperty, int? OptionalIntProperty);
+public sealed record ParentRequiredExample(string Id)
+{
+    public sealed record RequiredExample(IReadOnlyCollection<RequiredExample.Example> Examples, string? OptionalStringProperty)
+    {
+        public sealed record Example(string RequiredId);
+    }
+}

--- a/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
@@ -13,12 +13,46 @@ public class RequiredTypeController : ControllerBase
     {
         return this.Ok();
     }
+
+    [HttpGet("/classRequiredType", Name = "GetClassRequiredType")]
+    [ProducesResponseType(typeof(ParentRequiredExampleClass), StatusCodes.Status200OK)]
+    public IActionResult ClassRequiredType()
+    {
+        return this.Ok();
+    }
 }
 
 public sealed record ParentRequiredExample(string Id)
 {
     public sealed record RequiredExample(IReadOnlyCollection<RequiredExample.Example> Examples, string? OptionalStringProperty)
     {
-        public sealed record Example(string RequiredId);
+        public sealed record Example(IReadOnlyCollection<Example.Result> Results, string Property)
+        {
+            public sealed record Result(string Id, string? OptionalProperty);
+        }
     }
+}
+
+public sealed class ParentRequiredExampleClass(RequiredExampleClass requiredExample, string? optionalStringProperty)
+{
+    public RequiredExampleClass RequiredExample { get; } = requiredExample;
+    public string? OptionalStringProperty { get; } = optionalStringProperty;
+}
+
+public sealed class RequiredExampleClass(IReadOnlyCollection<ExampleClass> Examples, string? OptionalStringProperty)
+{
+    public IReadOnlyCollection<ExampleClass> Examples { get; } = Examples;
+    public string? OptionalStringProperty { get; } = OptionalStringProperty;
+}
+
+public sealed class ExampleClass(IReadOnlyCollection<ResultClass> Results, string Property)
+{
+    public IReadOnlyCollection<ResultClass> Results { get; } = Results;
+    public string Property { get; } = Property;
+}
+
+public sealed class ResultClass(string Id, string? OptionalProperty)
+{
+    public string Id { get; } = Id;
+    public string? OptionalProperty { get; } = OptionalProperty;
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/RequiredType/RequiredTypeController.cs
@@ -15,7 +15,7 @@ public class RequiredTypeController : ControllerBase
     }
 
     [HttpGet("/classRequiredType", Name = "GetClassRequiredType")]
-    [ProducesResponseType(typeof(ParentRequiredExampleClass), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(RequiredExampleGrandParentClass), StatusCodes.Status200OK)]
     public IActionResult ClassRequiredType()
     {
         return this.Ok();
@@ -33,26 +33,26 @@ public sealed record ParentRequiredExample(string Id)
     }
 }
 
-public sealed class ParentRequiredExampleClass(RequiredExampleClass requiredExample, string? optionalStringProperty)
+public sealed class RequiredExampleGrandParentClass(RequiredExampleParentClass requiredExampleParent, string? optionalStringProperty)
 {
-    public RequiredExampleClass RequiredExample { get; } = requiredExample;
+    public RequiredExampleParentClass RequiredExampleParent { get; } = requiredExampleParent;
     public string? OptionalStringProperty { get; } = optionalStringProperty;
 }
 
-public sealed class RequiredExampleClass(IReadOnlyCollection<ExampleClass> Examples, string? OptionalStringProperty)
+public sealed class RequiredExampleParentClass(IReadOnlyCollection<RequiredExampleClass> requiredExamples, string? optionalStringProperty)
 {
-    public IReadOnlyCollection<ExampleClass> Examples { get; } = Examples;
-    public string? OptionalStringProperty { get; } = OptionalStringProperty;
+    public IReadOnlyCollection<RequiredExampleClass> Examples { get; } = requiredExamples;
+    public string? OptionalStringProperty { get; } = optionalStringProperty;
 }
 
-public sealed class ExampleClass(IReadOnlyCollection<ResultClass> Results, string Property)
+public sealed class RequiredExampleClass(IReadOnlyCollection<ResultExampleClass> resultExamples, string property)
 {
-    public IReadOnlyCollection<ResultClass> Results { get; } = Results;
-    public string Property { get; } = Property;
+    public IReadOnlyCollection<ResultExampleClass> Results { get; } = resultExamples;
+    public string Property { get; } = property;
 }
 
-public sealed class ResultClass(string Id, string? OptionalProperty)
+public sealed class ResultExampleClass(string id, string? optionalProperty)
 {
-    public string Id { get; } = Id;
-    public string? OptionalProperty { get; } = OptionalProperty;
+    public string Id { get; } = id;
+    public string? OptionalProperty { get; } = optionalProperty;
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -268,6 +268,14 @@ paths:
                 type: string
 components:
   schemas:
+    Example:
+      required:
+        - requiredId
+      type: object
+      properties:
+        requiredId:
+          type: string
+      additionalProperties: false
     ProblemDetails:
       type: object
       properties:
@@ -290,21 +298,15 @@ components:
       additionalProperties: { }
     RequiredExample:
       required:
-        - requiredIntProperty
-        - requiredStringProperty
+        - examples
       type: object
       properties:
-        requiredIntProperty:
-          type: integer
-          format: int32
-        requiredStringProperty:
-          type: string
+        examples:
+          type: array
+          items:
+            $ref: '#/components/schemas/Example'
         optionalStringProperty:
           type: string
-          nullable: true
-        optionalIntProperty:
-          type: integer
-          format: int32
           nullable: true
       additionalProperties: false
     TypedResultExample:

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -54,6 +54,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequiredExample'
+  /classRequiredType:
+    get:
+      tags:
+        - RequiredType
+      operationId: GetClassRequiredType
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParentRequiredExampleClass'
   '/minimal-endpoint-with-typed-result-no-produces/{id}':
     get:
       tags:
@@ -270,11 +282,40 @@ components:
   schemas:
     Example:
       required:
-        - requiredId
+        - property
+        - results
       type: object
       properties:
-        requiredId:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Result'
+        property:
           type: string
+      additionalProperties: false
+    ExampleClass:
+      required:
+        - property
+        - results
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultClass'
+        property:
+          type: string
+      additionalProperties: false
+    ParentRequiredExampleClass:
+      required:
+        - requiredExample
+      type: object
+      properties:
+        requiredExample:
+          $ref: '#/components/schemas/RequiredExampleClass'
+        optionalStringProperty:
+          type: string
+          nullable: true
       additionalProperties: false
     ProblemDetails:
       type: object
@@ -306,6 +347,41 @@ components:
           items:
             $ref: '#/components/schemas/Example'
         optionalStringProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RequiredExampleClass:
+      required:
+        - examples
+      type: object
+      properties:
+        examples:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExampleClass'
+        optionalStringProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    Result:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: string
+        optionalProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ResultClass:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: string
+        optionalProperty:
           type: string
           nullable: true
       additionalProperties: false

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -53,7 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequiredExample'
+                $ref: '#/components/schemas/RequiredExampleGrandParentRecord'
   /classRequiredType:
     get:
       tags:
@@ -280,19 +280,6 @@ paths:
                 type: string
 components:
   schemas:
-    Example:
-      required:
-        - property
-        - results
-      type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/Result'
-        property:
-          type: string
-      additionalProperties: false
     ProblemDetails:
       type: object
       properties:
@@ -313,30 +300,17 @@ components:
           type: string
           nullable: true
       additionalProperties: { }
-    RequiredExample:
-      required:
-        - examples
-      type: object
-      properties:
-        examples:
-          type: array
-          items:
-            $ref: '#/components/schemas/Example'
-        optionalStringProperty:
-          type: string
-          nullable: true
-      additionalProperties: false
     RequiredExampleClass:
       required:
-        - property
-        - resultExamples
+        - exampleProperty
+        - results
       type: object
       properties:
-        resultExamples:
+        results:
           type: array
           items:
-            $ref: '#/components/schemas/ResultExampleClass'
-        property:
+            $ref: '#/components/schemas/ResultClass'
+        exampleProperty:
           type: string
       additionalProperties: false
     RequiredExampleGrandParentClass:
@@ -346,7 +320,18 @@ components:
       properties:
         requiredExampleParent:
           $ref: '#/components/schemas/RequiredExampleParentClass'
-        optionalStringProperty:
+        optionalGrandParentProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RequiredExampleGrandParentRecord:
+      required:
+        - requiredExampleParent
+      type: object
+      properties:
+        requiredExampleParent:
+          $ref: '#/components/schemas/RequiredExampleParentRecord'
+        optionalGrandParentProperty:
           type: string
           nullable: true
       additionalProperties: false
@@ -359,29 +344,55 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RequiredExampleClass'
-        optionalStringProperty:
+        optionalParentProperty:
           type: string
           nullable: true
       additionalProperties: false
-    Result:
+    RequiredExampleParentRecord:
       required:
-        - id
+        - requiredExamples
       type: object
       properties:
-        id:
-          type: string
-        optionalProperty:
+        requiredExamples:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequiredExampleRecord'
+        optionalParentProperty:
           type: string
           nullable: true
       additionalProperties: false
-    ResultExampleClass:
+    RequiredExampleRecord:
       required:
-        - id
+        - exampleProperty
+        - results
       type: object
       properties:
-        id:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultRecord'
+        exampleProperty:
           type: string
-        optionalProperty:
+      additionalProperties: false
+    ResultClass:
+      required:
+        - resultId
+      type: object
+      properties:
+        resultId:
+          type: string
+        optionalResultProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ResultRecord:
+      required:
+        - resultId
+      type: object
+      properties:
+        resultId:
+          type: string
+        optionalResultProperty:
           type: string
           nullable: true
       additionalProperties: false

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -329,14 +329,13 @@ components:
     RequiredExampleClass:
       required:
         - property
-        - results
+        - resultExamples
       type: object
       properties:
-        results:
+        resultExamples:
           type: array
           items:
             $ref: '#/components/schemas/ResultExampleClass'
-          readOnly: true
         property:
           type: string
       additionalProperties: false
@@ -353,14 +352,13 @@ components:
       additionalProperties: false
     RequiredExampleParentClass:
       required:
-        - examples
+        - requiredExamples
       type: object
       properties:
-        examples:
+        requiredExamples:
           type: array
           items:
             $ref: '#/components/schemas/RequiredExampleClass'
-          readOnly: true
         optionalStringProperty:
           type: string
           nullable: true

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -65,7 +65,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ParentRequiredExampleClass'
+                $ref: '#/components/schemas/RequiredExampleGrandParentClass'
   '/minimal-endpoint-with-typed-result-no-produces/{id}':
     get:
       tags:
@@ -293,30 +293,6 @@ components:
         property:
           type: string
       additionalProperties: false
-    ExampleClass:
-      required:
-        - property
-        - results
-      type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResultClass'
-        property:
-          type: string
-      additionalProperties: false
-    ParentRequiredExampleClass:
-      required:
-        - requiredExample
-      type: object
-      properties:
-        requiredExample:
-          $ref: '#/components/schemas/RequiredExampleClass'
-        optionalStringProperty:
-          type: string
-          nullable: true
-      additionalProperties: false
     ProblemDetails:
       type: object
       properties:
@@ -352,13 +328,39 @@ components:
       additionalProperties: false
     RequiredExampleClass:
       required:
+        - property
+        - results
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultExampleClass'
+          readOnly: true
+        property:
+          type: string
+      additionalProperties: false
+    RequiredExampleGrandParentClass:
+      required:
+        - requiredExampleParent
+      type: object
+      properties:
+        requiredExampleParent:
+          $ref: '#/components/schemas/RequiredExampleParentClass'
+        optionalStringProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RequiredExampleParentClass:
+      required:
         - examples
       type: object
       properties:
         examples:
           type: array
           items:
-            $ref: '#/components/schemas/ExampleClass'
+            $ref: '#/components/schemas/RequiredExampleClass'
+          readOnly: true
         optionalStringProperty:
           type: string
           nullable: true
@@ -374,7 +376,7 @@ components:
           type: string
           nullable: true
       additionalProperties: false
-    ResultClass:
+    ResultExampleClass:
       required:
         - id
       type: object

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -268,6 +268,14 @@ paths:
                 type: string
 components:
   schemas:
+    Example:
+      required:
+        - requiredId
+      type: object
+      properties:
+        requiredId:
+          type: string
+      additionalProperties: false
     ProblemDetails:
       type: object
       properties:
@@ -290,21 +298,15 @@ components:
       additionalProperties: { }
     RequiredExample:
       required:
-        - requiredIntProperty
-        - requiredStringProperty
+        - examples
       type: object
       properties:
-        requiredIntProperty:
-          type: integer
-          format: int32
-        requiredStringProperty:
-          type: string
+        examples:
+          type: array
+          items:
+            $ref: '#/components/schemas/Example'
         optionalStringProperty:
           type: string
-          nullable: true
-        optionalIntProperty:
-          type: integer
-          format: int32
           nullable: true
       additionalProperties: false
     TypedResultExample:

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -54,6 +54,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequiredExample'
+  /classRequiredType:
+    get:
+      tags:
+        - RequiredType
+      operationId: GetClassRequiredType
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParentRequiredExampleClass'
   '/minimal-endpoint-with-typed-result-no-produces/{id}':
     get:
       tags:
@@ -270,11 +282,40 @@ components:
   schemas:
     Example:
       required:
-        - requiredId
+        - property
+        - results
       type: object
       properties:
-        requiredId:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Result'
+        property:
           type: string
+      additionalProperties: false
+    ExampleClass:
+      required:
+        - property
+        - results
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultClass'
+        property:
+          type: string
+      additionalProperties: false
+    ParentRequiredExampleClass:
+      required:
+        - requiredExample
+      type: object
+      properties:
+        requiredExample:
+          $ref: '#/components/schemas/RequiredExampleClass'
+        optionalStringProperty:
+          type: string
+          nullable: true
       additionalProperties: false
     ProblemDetails:
       type: object
@@ -306,6 +347,41 @@ components:
           items:
             $ref: '#/components/schemas/Example'
         optionalStringProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RequiredExampleClass:
+      required:
+        - examples
+      type: object
+      properties:
+        examples:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExampleClass'
+        optionalStringProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    Result:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: string
+        optionalProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ResultClass:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: string
+        optionalProperty:
           type: string
           nullable: true
       additionalProperties: false

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -53,7 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequiredExample'
+                $ref: '#/components/schemas/RequiredExampleGrandParentRecord'
   /classRequiredType:
     get:
       tags:
@@ -280,19 +280,6 @@ paths:
                 type: string
 components:
   schemas:
-    Example:
-      required:
-        - property
-        - results
-      type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/Result'
-        property:
-          type: string
-      additionalProperties: false
     ProblemDetails:
       type: object
       properties:
@@ -313,30 +300,17 @@ components:
           type: string
           nullable: true
       additionalProperties: { }
-    RequiredExample:
-      required:
-        - examples
-      type: object
-      properties:
-        examples:
-          type: array
-          items:
-            $ref: '#/components/schemas/Example'
-        optionalStringProperty:
-          type: string
-          nullable: true
-      additionalProperties: false
     RequiredExampleClass:
       required:
-        - property
-        - resultExamples
+        - exampleProperty
+        - results
       type: object
       properties:
-        resultExamples:
+        results:
           type: array
           items:
-            $ref: '#/components/schemas/ResultExampleClass'
-        property:
+            $ref: '#/components/schemas/ResultClass'
+        exampleProperty:
           type: string
       additionalProperties: false
     RequiredExampleGrandParentClass:
@@ -346,7 +320,18 @@ components:
       properties:
         requiredExampleParent:
           $ref: '#/components/schemas/RequiredExampleParentClass'
-        optionalStringProperty:
+        optionalGrandParentProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RequiredExampleGrandParentRecord:
+      required:
+        - requiredExampleParent
+      type: object
+      properties:
+        requiredExampleParent:
+          $ref: '#/components/schemas/RequiredExampleParentRecord'
+        optionalGrandParentProperty:
           type: string
           nullable: true
       additionalProperties: false
@@ -359,29 +344,55 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RequiredExampleClass'
-        optionalStringProperty:
+        optionalParentProperty:
           type: string
           nullable: true
       additionalProperties: false
-    Result:
+    RequiredExampleParentRecord:
       required:
-        - id
+        - requiredExamples
       type: object
       properties:
-        id:
-          type: string
-        optionalProperty:
+        requiredExamples:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequiredExampleRecord'
+        optionalParentProperty:
           type: string
           nullable: true
       additionalProperties: false
-    ResultExampleClass:
+    RequiredExampleRecord:
       required:
-        - id
+        - exampleProperty
+        - results
       type: object
       properties:
-        id:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultRecord'
+        exampleProperty:
           type: string
-        optionalProperty:
+      additionalProperties: false
+    ResultClass:
+      required:
+        - resultId
+      type: object
+      properties:
+        resultId:
+          type: string
+        optionalResultProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ResultRecord:
+      required:
+        - resultId
+      type: object
+      properties:
+        resultId:
+          type: string
+        optionalResultProperty:
           type: string
           nullable: true
       additionalProperties: false

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -329,14 +329,13 @@ components:
     RequiredExampleClass:
       required:
         - property
-        - results
+        - resultExamples
       type: object
       properties:
-        results:
+        resultExamples:
           type: array
           items:
             $ref: '#/components/schemas/ResultExampleClass'
-          readOnly: true
         property:
           type: string
       additionalProperties: false
@@ -353,14 +352,13 @@ components:
       additionalProperties: false
     RequiredExampleParentClass:
       required:
-        - examples
+        - requiredExamples
       type: object
       properties:
-        examples:
+        requiredExamples:
           type: array
           items:
             $ref: '#/components/schemas/RequiredExampleClass'
-          readOnly: true
         optionalStringProperty:
           type: string
           nullable: true

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -65,7 +65,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ParentRequiredExampleClass'
+                $ref: '#/components/schemas/RequiredExampleGrandParentClass'
   '/minimal-endpoint-with-typed-result-no-produces/{id}':
     get:
       tags:
@@ -293,30 +293,6 @@ components:
         property:
           type: string
       additionalProperties: false
-    ExampleClass:
-      required:
-        - property
-        - results
-      type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResultClass'
-        property:
-          type: string
-      additionalProperties: false
-    ParentRequiredExampleClass:
-      required:
-        - requiredExample
-      type: object
-      properties:
-        requiredExample:
-          $ref: '#/components/schemas/RequiredExampleClass'
-        optionalStringProperty:
-          type: string
-          nullable: true
-      additionalProperties: false
     ProblemDetails:
       type: object
       properties:
@@ -352,13 +328,39 @@ components:
       additionalProperties: false
     RequiredExampleClass:
       required:
+        - property
+        - results
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultExampleClass'
+          readOnly: true
+        property:
+          type: string
+      additionalProperties: false
+    RequiredExampleGrandParentClass:
+      required:
+        - requiredExampleParent
+      type: object
+      properties:
+        requiredExampleParent:
+          $ref: '#/components/schemas/RequiredExampleParentClass'
+        optionalStringProperty:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RequiredExampleParentClass:
+      required:
         - examples
       type: object
       properties:
         examples:
           type: array
           items:
-            $ref: '#/components/schemas/ExampleClass'
+            $ref: '#/components/schemas/RequiredExampleClass'
+          readOnly: true
         optionalStringProperty:
           type: string
           nullable: true
@@ -374,7 +376,7 @@ components:
           type: string
           nullable: true
       additionalProperties: false
-    ResultClass:
+    ResultExampleClass:
       required:
         - id
       type: object


### PR DESCRIPTION
## Description of changes
Nested records where the parent class does not have a nullable property placed all property of the child class as nullable. This is seems to be an issue with Swashbuckle. As such, the fix is to parse the nested schema properties and match with the reflected class properties.

## Breaking changes
None

## Additional checks
Run system tests.

- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes