### PR TITLE
Add correct Nuget source and API key to publish to nuget.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
       - run: ./Build.ps1
         shell: pwsh
         env:
-          NUGET_SOURCE: ${{ secrets.NUGET_GSOFTDEV_FEED_URL }}
-          NUGET_API_KEY: ${{ secrets.GSOFT_NUGET_API_KEY }}
+          NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
+          NUGET_API_KEY: ${{ secrets.WORKLEAP_NUGET_API_KEY }}


### PR DESCRIPTION
## Description of changes
Given that we tagged the latest 0.1.0 version, we can should use the correct Nuget API key and source to publish to nuget.org. 