### PR TITLE
[IDP-1405] Support Forbidden and ForbiddenOfT in TypedResultExtensions

### DIFF
--- a/src/Shared/HttpResultsStatusCodeTypeHelpers.cs
+++ b/src/Shared/HttpResultsStatusCodeTypeHelpers.cs
@@ -16,17 +16,19 @@ internal static class HttpResultsStatusCodeTypeHelpers
         {"Microsoft.AspNetCore.Http.HttpResults.BadRequest", 400},
         {"Microsoft.AspNetCore.Http.HttpResults.BadRequest`1", 400},
         {"Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult", 401},
+        {"Workleap.Extensions.OpenAPI.TypedResult.Forbidden", 403},
+        {"Workleap.Extensions.OpenAPI.TypedResult.Forbidden`1", 403},
         {"Microsoft.AspNetCore.Http.HttpResults.NotFound", 404},
         {"Microsoft.AspNetCore.Http.HttpResults.NotFound`1", 404},
         {"Microsoft.AspNetCore.Http.HttpResults.Conflict", 409},
         {"Microsoft.AspNetCore.Http.HttpResults.Conflict`1", 409},
         {"Microsoft.AspNetCore.Http.HttpResults.UnprocessableEntity", 422},
-        {"Microsoft.AspNetCore.Http.HttpResults.UnprocessableEntity`T", 422},
+        {"Microsoft.AspNetCore.Http.HttpResults.UnprocessableEntity`1", 422},
         // Will be Supported in .NET 9
         {"Microsoft.AspNetCore.Http.HttpResults.InternalServerError", 500},
         {"Microsoft.AspNetCore.Http.HttpResults.InternalServerError`1", 500},
         // Workleap's definition of the InternalServerError type result for other .NET versions
         {"Workleap.Extensions.OpenAPI.TypedResult.InternalServerError", 500},
-        {"Workleap.Extensions.OpenAPI.TypedResult.InternalServerError`1", 500}
+        {"Workleap.Extensions.OpenAPI.TypedResult.InternalServerError`1", 500},
     };
 }

--- a/src/Workleap.Extensions.OpenAPI.Analyzers/CompareTypedResultWithAnnotationAnalyzer.cs
+++ b/src/Workleap.Extensions.OpenAPI.Analyzers/CompareTypedResultWithAnnotationAnalyzer.cs
@@ -83,6 +83,7 @@ public class CompareTypedResultWithAnnotationAnalyzer : DiagnosticAnalyzer
             Add(204, "Microsoft.AspNetCore.Http.HttpResults.NoContent");
             Add(400, "Microsoft.AspNetCore.Http.HttpResults.BadRequest");
             Add(401, "Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult");
+            Add(403, "Workleap.Extensions.OpenAPI.TypedResult.Forbidden");
             Add(404, "Microsoft.AspNetCore.Http.HttpResults.NotFound");
             Add(409, "Microsoft.AspNetCore.Http.HttpResults.Conflict");
             Add(422, "Microsoft.AspNetCore.Http.HttpResults.UnprocessableEntity");

--- a/src/Workleap.Extensions.OpenAPI.Analyzers/EnforceTypedResultsReturnAnalyzer.cs
+++ b/src/Workleap.Extensions.OpenAPI.Analyzers/EnforceTypedResultsReturnAnalyzer.cs
@@ -38,10 +38,11 @@ public class EnforceTypedResultsReturnAnalyzer : DiagnosticAnalyzer
     {
         private INamedTypeSymbol? TaskOfTSymbol { get; } = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
         private INamedTypeSymbol? ValueTaskOfTSymbol { get; } = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
-        private INamedTypeSymbol? ResultSymbol { get; } = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Http.IResult");
-        private INamedTypeSymbol? ActionResultSymbol { get; } = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.IActionResult");
+        private INamedTypeSymbol? ResultInterfaceSymbol { get; } = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Http.IResult");
+        private INamedTypeSymbol? ActionResultInterfaceSymbol { get; } = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.IActionResult");
+        private INamedTypeSymbol? ActionResultSymbol { get; } = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.ActionResult");
 
-        public bool IsValid => this.ActionResultSymbol is not null || this.ResultSymbol is not null;
+        public bool IsValid => this.ActionResultInterfaceSymbol is not null || this.ResultInterfaceSymbol is not null;
 
         public void ValidateEndpointResponseType(SymbolAnalysisContext context)
         {
@@ -70,7 +71,9 @@ public class EnforceTypedResultsReturnAnalyzer : DiagnosticAnalyzer
 
         private bool IsWeaklyTypedResults(ITypeSymbol currentClassSymbol)
         {
-            return SymbolEqualityComparer.Default.Equals(currentClassSymbol, this.ResultSymbol) || SymbolEqualityComparer.Default.Equals(currentClassSymbol, this.ActionResultSymbol);
+            return SymbolEqualityComparer.Default.Equals(currentClassSymbol, this.ResultInterfaceSymbol)
+                   || SymbolEqualityComparer.Default.Equals(currentClassSymbol, this.ActionResultInterfaceSymbol)
+                   || SymbolEqualityComparer.Default.Equals(currentClassSymbol, this.ActionResultSymbol);
         }
     }
 }

--- a/src/Workleap.Extensions.OpenAPI/PublicAPI.Unshipped.txt
+++ b/src/Workleap.Extensions.OpenAPI/PublicAPI.Unshipped.txt
@@ -1,10 +1,17 @@
 #nullable enable
 static Workleap.Extensions.OpenAPI.OpenApiServiceCollectionExtensions.ConfigureOpenApiGeneration(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Workleap.Extensions.OpenAPI.Builder.OpenApiBuilder!
+static Workleap.Extensions.OpenAPI.TypedResult.TypedResultsExtensions.Forbidden() -> Workleap.Extensions.OpenAPI.TypedResult.Forbidden!
+static Workleap.Extensions.OpenAPI.TypedResult.TypedResultsExtensions.Forbidden<T>(T? error) -> Workleap.Extensions.OpenAPI.TypedResult.Forbidden<T>!
 static Workleap.Extensions.OpenAPI.TypedResult.TypedResultsExtensions.InternalServerError() -> Workleap.Extensions.OpenAPI.TypedResult.InternalServerError!
 static Workleap.Extensions.OpenAPI.TypedResult.TypedResultsExtensions.InternalServerError<T>(T? error) -> Workleap.Extensions.OpenAPI.TypedResult.InternalServerError<T>!
 Workleap.Extensions.OpenAPI.Builder.OpenApiBuilder
 Workleap.Extensions.OpenAPI.Builder.OpenApiBuilder.GenerateMissingOperationId() -> Workleap.Extensions.OpenAPI.Builder.OpenApiBuilder!
 Workleap.Extensions.OpenAPI.OpenApiServiceCollectionExtensions
+Workleap.Extensions.OpenAPI.TypedResult.Forbidden
+Workleap.Extensions.OpenAPI.TypedResult.Forbidden.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
+Workleap.Extensions.OpenAPI.TypedResult.Forbidden<TValue>
+Workleap.Extensions.OpenAPI.TypedResult.Forbidden<TValue>.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
+Workleap.Extensions.OpenAPI.TypedResult.Forbidden<TValue>.Value.get -> TValue?
 Workleap.Extensions.OpenAPI.TypedResult.InternalServerError
 Workleap.Extensions.OpenAPI.TypedResult.InternalServerError.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
 Workleap.Extensions.OpenAPI.TypedResult.InternalServerError<TValue>

--- a/src/Workleap.Extensions.OpenAPI/TypedResult/FobiddenOfT.cs
+++ b/src/Workleap.Extensions.OpenAPI/TypedResult/FobiddenOfT.cs
@@ -1,0 +1,69 @@
+using System.Net.Mime;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Workleap.Extensions.OpenAPI.TypedResult;
+
+/// <summary>
+/// An <see cref="IResult"/> that on execution will write an object to the response
+/// with Forbidden (403) status code.
+/// </summary>
+/// <typeparam name="TValue">The type of error object that will be JSON serialized to the response body.</typeparam>
+#pragma warning disable SA1649 // File name should match first type name - This is a Generic class.
+public sealed class Forbidden<TValue> : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue>
+{
+#pragma warning restore SA1649
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Forbidden"/> class with the values
+    /// provided.
+    /// </summary>
+    /// <param name="error">The error content to format in the entity body.</param>
+    internal Forbidden(TValue? error)
+    {
+        this.Value = error;
+        if (this.Value is ProblemDetails problemDetails)
+        {
+            problemDetails.Type = "https://tools.ietf.org/html/rfc9110#section-15.5.4";
+            problemDetails.Title = "Forbidden";
+        }
+    }
+
+    /// <summary>
+    /// Gets the object result.
+    /// </summary>
+    public TValue? Value { get; }
+
+    object? IValueHttpResult.Value => this.Value;
+
+    /// <summary>
+    /// Gets the HTTP status code: <see cref="StatusCodes.Status403Forbidden"/>
+    /// </summary>
+    private static int StatusCode => StatusCodes.Status403Forbidden;
+
+    int? IStatusCodeHttpResult.StatusCode => StatusCode;
+
+    private static readonly string[] ContentTypes = new[] { "application/json" };
+
+    /// <inheritdoc/>
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        httpContext.Response.ContentType = MediaTypeNames.Application.Json;
+        httpContext.Response.StatusCode = StatusCode;
+
+        return httpContext.Response.WriteAsJsonAsync(
+            this.Value);
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status403Forbidden, typeof(TValue), ContentTypes));
+    }
+}

--- a/src/Workleap.Extensions.OpenAPI/TypedResult/Forbidden.cs
+++ b/src/Workleap.Extensions.OpenAPI/TypedResult/Forbidden.cs
@@ -7,22 +7,22 @@ namespace Workleap.Extensions.OpenAPI.TypedResult;
 
 /// <summary>
 /// An <see cref="IResult"/> that on execution will write an object to the response
-/// with Internal Server Error (500) status code.
+/// with Forbidden (403) status code.
 /// </summary>
-public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult
+public sealed class Forbidden : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="InternalServerError"/> class with the values
+    /// Initializes a new instance of the <see cref="Forbidden"/> class with the values
     /// provided.
     /// </summary>
-    internal InternalServerError()
+    internal Forbidden()
     {
     }
 
     /// <summary>
-    /// Gets the HTTP status code: <see cref="StatusCodes.Status500InternalServerError"/>
+    /// Gets the HTTP status code: <see cref="StatusCodes.Status403Forbidden"/>
     /// </summary>
-    private int StatusCode => StatusCodes.Status500InternalServerError;
+    private int StatusCode => StatusCodes.Status403Forbidden;
 
     int? IStatusCodeHttpResult.StatusCode => this.StatusCode;
 
@@ -41,6 +41,6 @@ public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IS
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status500InternalServerError, typeof(void)));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status403Forbidden, typeof(void)));
     }
 }

--- a/src/Workleap.Extensions.OpenAPI/TypedResult/TypedResultsExtensions.cs
+++ b/src/Workleap.Extensions.OpenAPI/TypedResult/TypedResultsExtensions.cs
@@ -4,4 +4,7 @@ public static class TypedResultsExtensions
 {
     public static InternalServerError InternalServerError() => new();
     public static InternalServerError<T> InternalServerError<T>(T? error) => new(error);
+
+    public static Forbidden Forbidden() => new();
+    public static Forbidden<T> Forbidden<T>(T? error) => new(error);
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
@@ -46,14 +46,61 @@ public class TypedResultController : ControllerBase
     }
 
     [HttpGet]
-    [Route("/withNoAnnotationForAcceptedAndUnprocessableResponse")]
-    public Results<Ok<TypedResultExample>, Accepted<TypedResultExample>, UnprocessableEntity> TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponse(int id)
+    [Route("/withNoAnnotationForAcceptedAndUnprocessableResponseNoType")]
+    public Results<Ok<TypedResultExample>, Accepted, UnprocessableEntity> TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponseNoType(int id)
     {
         return id switch
         {
             < 0 => TypedResults.UnprocessableEntity(),
             0 => TypedResults.Ok(new TypedResultExample("Example")),
-            _ => TypedResults.Accepted("hardcoded uri", new TypedResultExample("Example"))
+            _ => TypedResults.Accepted("hardcoded uri")
+        };
+    }
+
+    [HttpGet]
+    [Route("/withNoAnnotationForAcceptedAndUnprocessableResponseWithType")]
+    public Results<Ok<TypedResultExample>, Accepted<TypedResultExample>, UnprocessableEntity<TypedResultExample>> TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponseWithType(int id)
+    {
+        return id switch
+        {
+            < 0 => TypedResults.UnprocessableEntity(new TypedResultExample("Example")),
+            0 => TypedResults.Ok(new TypedResultExample("Example")),
+            _ => TypedResults.Accepted("hardcoded uri", new TypedResultExample("example"))
+        };
+    }
+
+    [HttpGet]
+    [Route("/withNoAnnotationForCreatedAndConflictNoType")]
+    public Results<Ok<TypedResultExample>, Created, Conflict> TypedResultWithNoAnnotationForCreatedAndConflictNoType(int id)
+    {
+        return id switch
+        {
+            < 0 => TypedResults.Conflict(),
+            0 => TypedResults.Ok(new TypedResultExample("Example")),
+            _ => TypedResults.Created()
+        };
+    }
+
+    [HttpGet]
+    [Route("/withNoAnnotationForCreatedAndConflictWithType")]
+    public Results<Ok<TypedResultExample>, Created<string>, Conflict<string>> TypedResultWithNoAnnotationForCreatedAndConflictWithType(int id)
+    {
+        return id switch
+        {
+            < 0 => TypedResults.Conflict("Conflict"),
+            0 => TypedResults.Ok(new TypedResultExample("Example")),
+            _ => TypedResults.Created("hardcoded uri", "Created")
+        };
+    }
+
+    [HttpGet]
+    [Route("/withNoAnnotationForNoContentAndUnauthorized")]
+    public Results<NoContent, UnauthorizedHttpResult> TypedResultWithNoAnnotationForNoContentAndUnauthorized(int id)
+    {
+        return id switch
+        {
+            < 0 => TypedResults.NoContent(),
+            _ => TypedResults.Unauthorized()
         };
     }
 
@@ -73,8 +120,20 @@ public class TypedResultController : ControllerBase
     }
 
     [HttpGet]
-    [Route("/withExceptionsWithExtensions")]
-    public Results<Ok<TypedResultExample>, Forbidden<string>, InternalServerError<string>> TypedResultWithExceptionsWithExtensions(int id)
+    [Route("/withExceptionsNoType")]
+    public Results<Ok<TypedResultExample>, Forbidden, InternalServerError> TypedResultWithExceptionsNoType(int id)
+    {
+        return id switch
+        {
+            0 => TypedResultsExtensions.Forbidden(),
+            < 0 => TypedResultsExtensions.InternalServerError(),
+            _ => TypedResults.Ok(new TypedResultExample("Example"))
+        };
+    }
+
+    [HttpGet]
+    [Route("/withExceptionsWithType")]
+    public Results<Ok<TypedResultExample>, Forbidden<string>, InternalServerError<string>> TypedResultWithExceptionsWithType(int id)
     {
         return id switch
         {

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
@@ -74,10 +74,11 @@ public class TypedResultController : ControllerBase
 
     [HttpGet]
     [Route("/withExceptionsWithExtensions")]
-    public Results<Ok<TypedResultExample>, InternalServerError<string>> TypedResultWithExceptionsWithExtensions(int id)
+    public Results<Ok<TypedResultExample>, Forbidden<string>, InternalServerError<string>> TypedResultWithExceptionsWithExtensions(int id)
     {
         return id switch
         {
+            0 => TypedResultsExtensions.Forbidden("Forbidden"),
             < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
             _ => TypedResults.Ok(new TypedResultExample("Example"))
         };

--- a/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
+++ b/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.6.0">
+    <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -199,11 +199,34 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
         '404':
           description: '404'
-  /withNoAnnotationForAcceptedAndUnprocessableResponse:
+  /withNoAnnotationForAcceptedAndUnprocessableResponseNoType:
     get:
       tags:
         - TypedResult
-      operationId: TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponse
+      operationId: TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponseNoType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '202':
+          description: '202'
+        '422':
+          description: '422'
+  /withNoAnnotationForAcceptedAndUnprocessableResponseWithType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponseWithType
       parameters:
         - name: id
           in: query
@@ -226,6 +249,83 @@ paths:
                 $ref: '#/components/schemas/TypedResultExample'
         '422':
           description: '422'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+  /withNoAnnotationForCreatedAndConflictNoType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForCreatedAndConflictNoType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '201':
+          description: '201'
+        '409':
+          description: '409'
+  /withNoAnnotationForCreatedAndConflictWithType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForCreatedAndConflictWithType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '201':
+          description: '201'
+          content:
+            application/json:
+              schema:
+                type: string
+        '409':
+          description: '409'
+          content:
+            application/json:
+              schema:
+                type: string
+  /withNoAnnotationForNoContentAndUnauthorized:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForNoContentAndUnauthorized
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Success
+        '204':
+          description: '204'
+        '401':
+          description: '401'
   /voidOk:
     get:
       tags:
@@ -253,11 +353,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TypedResultExample'
-  /withExceptionsWithExtensions:
+  /withExceptionsNoType:
     get:
       tags:
         - TypedResult
-      operationId: TypedResultWithExceptionsWithExtensions
+      operationId: TypedResultWithExceptionsNoType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+        '500':
+          description: '500'
+  /withExceptionsWithType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithExceptionsWithType
       parameters:
         - name: id
           in: query

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -272,6 +272,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+          content:
+            application/json:
+              schema:
+                type: string
         '500':
           description: '500'
           content:

--- a/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/CompareTypedResultWithAnnotationAnalyzerTests.cs
+++ b/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/CompareTypedResultWithAnnotationAnalyzerTests.cs
@@ -248,4 +248,21 @@ public class CompareTypedResultWithAnnotationAnalyzerTests : BaseAnalyzerTest<Co
         await this.WithSourceCode(source)
             .RunAsync();
     }
+
+    [Fact]
+    public async Task Given_ProducesResponseAndCorrectTypedResultsTaskWithForbidden_When_Analyze_Then_No_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                  [HttpGet]
+                                  [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+                                  [ProducesResponseType(StatusCodes.Status403Forbidden)]
+                                  public async Task<Results<Ok<string>, Forbidden>> GetSampleEndpoint() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
 }

--- a/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/EnforceTypedResultsReturnAnalyzerTests.cs
+++ b/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/EnforceTypedResultsReturnAnalyzerTests.cs
@@ -168,4 +168,34 @@ public class EnforceTypedResultsReturnAnalyzerTests : BaseAnalyzerTest<EnforceTy
         await this.WithSourceCode(source)
             .RunAsync();
     }
+
+    [Fact]
+    public async Task Given_ReturnActionResult_When_Analyze_Then_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                [HttpGet]
+                                public ActionResult {|WLOAS002:GetSampleEndpoint|}() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task Given_ReturnTaskOfActionResult_When_Analyze_Then_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                [HttpGet]
+                                public Task<ActionResult> {|WLOAS002:GetSampleEndpoint|}() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
 }

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -199,11 +199,34 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
         '404':
           description: '404'
-  /withNoAnnotationForAcceptedAndUnprocessableResponse:
+  /withNoAnnotationForAcceptedAndUnprocessableResponseNoType:
     get:
       tags:
         - TypedResult
-      operationId: TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponse
+      operationId: TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponseNoType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '202':
+          description: '202'
+        '422':
+          description: '422'
+  /withNoAnnotationForAcceptedAndUnprocessableResponseWithType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForAcceptedAndUnprocessableResponseWithType
       parameters:
         - name: id
           in: query
@@ -226,6 +249,83 @@ paths:
                 $ref: '#/components/schemas/TypedResultExample'
         '422':
           description: '422'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+  /withNoAnnotationForCreatedAndConflictNoType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForCreatedAndConflictNoType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '201':
+          description: '201'
+        '409':
+          description: '409'
+  /withNoAnnotationForCreatedAndConflictWithType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForCreatedAndConflictWithType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '201':
+          description: '201'
+          content:
+            application/json:
+              schema:
+                type: string
+        '409':
+          description: '409'
+          content:
+            application/json:
+              schema:
+                type: string
+  /withNoAnnotationForNoContentAndUnauthorized:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithNoAnnotationForNoContentAndUnauthorized
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Success
+        '204':
+          description: '204'
+        '401':
+          description: '401'
   /voidOk:
     get:
       tags:
@@ -253,11 +353,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TypedResultExample'
-  /withExceptionsWithExtensions:
+  /withExceptionsNoType:
     get:
       tags:
         - TypedResult
-      operationId: TypedResultWithExceptionsWithExtensions
+      operationId: TypedResultWithExceptionsNoType
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+        '500':
+          description: '500'
+  /withExceptionsWithType:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithExceptionsWithType
       parameters:
         - name: id
           in: query

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -272,6 +272,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+          content:
+            application/json:
+              schema:
+                type: string
         '500':
           description: '500'
           content:


### PR DESCRIPTION
## Description of changes
Support Forbidden and ForbiddenOfT as a possible response type. Currently, this HttpResult is not present in .NET8.0 and need to be added explicitly.

## Breaking changes
None.

- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes