### PR TITLE
[IDP-1424] Only return application/json content type for Typed responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ public Ok<TypedResultExample> EnforceStronglyTypedResponse() //This is a strongl
 
 ### Limitations
 
-We currently only support the extraction of the default media type and not any globally defined content types such as [`{ "application/json", "text/json", "text/plain", }`](https://learn.microsoft.com/en-us/aspnet/core/web-api/advanced/formatting?view=aspnetcore-8.0)
+[Given that HttpResults return types do not leverage the configured Formatters](https://learn.microsoft.com/en-us/aspnet/core/web-api/action-return-types?view=aspnetcore-8.0#httpresults-type), content negotiation is not supported for these endpoints and the produced Content-Type is decided by HttpResults implementation. For our use cases, it will be `application/json`.
+
 
 ## Building, releasing and versioning
 

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultNoProducesController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultNoProducesController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.OpenAPI.SystemTest.ExtractTypeResult;
+
+public class TypedResultNoProducesController
+{
+    [HttpGet]
+    [Route("/useApplicationJsonContentType")]
+    [ProducesResponseType<string>(StatusCodes.Status200OK, "text/plain")]
+    public Ok<string> TypedResultUseApplicationJsonContentType()
+    {
+        return TypedResults.Ok("example");
+    }
+}

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -407,6 +407,17 @@ paths:
             application/json:
               schema:
                 type: string
+  /useApplicationJsonContentType:
+    get:
+      tags:
+        - TypedResultNoProduces
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: string
 components:
   schemas:
     ProblemDetails:

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -407,6 +407,17 @@ paths:
             application/json:
               schema:
                 type: string
+  /useApplicationJsonContentType:
+    get:
+      tags:
+        - TypedResultNoProduces
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: string
 components:
   schemas:
     ProblemDetails:


### PR DESCRIPTION
## Description of changes
Given that HttpResults does not leverage content negociation, for our use cases, it would always return a `application/json` response. Attributes should affect the behavior of the responses.

## Breaking changes
None

- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes