### PR TITLE
[IDP-1491] Remove default 200 response codes if not defined

### DIFF
--- a/src/Workleap.Extensions.OpenAPI.Tests/TypedResult/ExtractSchemaTypeResultFilterTests.cs
+++ b/src/Workleap.Extensions.OpenAPI.Tests/TypedResult/ExtractSchemaTypeResultFilterTests.cs
@@ -13,21 +13,91 @@ public class ExtractSchemaTypeResultFilterTests
     public static IEnumerable<object[]> GetResponseMetadataData()
     {
         // Synchronous results
-        yield return new object[] { typeof(Ok<TestTypedSchema>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)) } };
-        yield return new object[] { typeof(Accepted<TestTypedSchema>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema)) } };
-        yield return new object[] { typeof(Results<Ok<TestTypedSchema>, Accepted<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)), new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema)), new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)), new((int)HttpStatusCode.NotFound, null) } };
-        yield return new object[] { typeof(Ok), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, null) } };
+        yield return new object[]
+        {
+            typeof(Ok<TestTypedSchema>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.OK, typeof(TestTypedSchema))
+            }
+        };
+        yield return new object[]
+        {
+            typeof(Accepted<TestTypedSchema>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema))
+            }
+        };
+        yield return new object[]
+        {
+            typeof(Results<Ok<TestTypedSchema>, Accepted<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.OK, typeof(TestTypedSchema)),
+                new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema)),
+                new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)),
+                new((int)HttpStatusCode.NotFound, null)
+            }
+        };
+        yield return new object[]
+        {
+            typeof(Ok),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.OK, null)
+            }
+        };
 
         // // Asynchronous results
-        yield return new object[] { typeof(Task<Ok<TestTypedSchema>>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)) } };
-        yield return new object[] { typeof(Task<Results<Ok<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)), new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)), new((int)HttpStatusCode.NotFound, null) } };
-        yield return new object[] { typeof(Task<Ok>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, null) } };
+        yield return new object[]
+        {
+            typeof(Task<Ok<TestTypedSchema>>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.OK, typeof(TestTypedSchema))
+            }
+        };
+        yield return new object[]
+        {
+            typeof(Task<Results<Ok<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.OK, typeof(TestTypedSchema)),
+                new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)),
+                new((int)HttpStatusCode.NotFound, null)
+            }
+        };
+        yield return new object[]
+        {
+            typeof(Task<Ok>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
+            {
+                new((int)HttpStatusCode.OK, null)
+            }
+        };
 
         // Common types we should ignore
-        yield return new object[] { typeof(IResult), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
-        yield return new object[] { typeof(IActionResult), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
-        yield return new object[] { typeof(ActionResult<TestTypedSchema>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
-        yield return new object[] { typeof(TestTypedSchema), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
+        yield return new object[]
+        {
+            typeof(IResult),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
+        };
+        yield return new object[]
+        {
+            typeof(IActionResult),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
+        };
+        yield return new object[]
+        {
+            typeof(ActionResult<TestTypedSchema>),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
+        };
+        yield return new object[]
+        {
+            typeof(TestTypedSchema),
+            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
+        };
     }
 
     public static IEnumerable<object[]> GetAttributesData()

--- a/src/Workleap.Extensions.OpenAPI.Tests/TypedResult/ExtractSchemaTypeResultFilterTests.cs
+++ b/src/Workleap.Extensions.OpenAPI.Tests/TypedResult/ExtractSchemaTypeResultFilterTests.cs
@@ -1,108 +1,59 @@
 ﻿using System.Net;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 using Workleap.Extensions.OpenAPI.TypedResult;
 
 namespace Workleap.Extensions.OpenAPI.Tests.TypedResult;
 
 public class ExtractSchemaTypeResultFilterTests
 {
-    public static IEnumerable<object[]> GetData()
+    public static IEnumerable<object[]> GetResponseMetadataData()
     {
         // Synchronous results
-        yield return new object[]
-        {
-            typeof(Ok<TestTypedSchema>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.OK, typeof(TestTypedSchema))
-            }
-        };
-        yield return new object[]
-        {
-            typeof(Accepted<TestTypedSchema>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema))
-            }
-        };
-        yield return new object[]
-        {
-            typeof(Results<Ok<TestTypedSchema>, Accepted<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.OK, typeof(TestTypedSchema)),
-                new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema)),
-                new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)),
-                new((int)HttpStatusCode.NotFound, null)
-            }
-        };
-        yield return new object[]
-        {
-            typeof(Ok),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.OK, null)
-            }
-        };
+        yield return new object[] { typeof(Ok<TestTypedSchema>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)) } };
+        yield return new object[] { typeof(Accepted<TestTypedSchema>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema)) } };
+        yield return new object[] { typeof(Results<Ok<TestTypedSchema>, Accepted<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)), new((int)HttpStatusCode.Accepted, typeof(TestTypedSchema)), new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)), new((int)HttpStatusCode.NotFound, null) } };
+        yield return new object[] { typeof(Ok), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, null) } };
 
         // // Asynchronous results
-        yield return new object[]
-        {
-            typeof(Task<Ok<TestTypedSchema>>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.OK, typeof(TestTypedSchema))
-            }
-        };
-        yield return new object[]
-        {
-            typeof(Task<Results<Ok<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.OK, typeof(TestTypedSchema)),
-                new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)),
-                new((int)HttpStatusCode.NotFound, null)
-            }
-        };
-        yield return new object[]
-        {
-            typeof(Task<Ok>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata>
-            {
-                new((int)HttpStatusCode.OK, null)
-            }
-        };
+        yield return new object[] { typeof(Task<Ok<TestTypedSchema>>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)) } };
+        yield return new object[] { typeof(Task<Results<Ok<TestTypedSchema>, BadRequest<ProblemDetails>, NotFound>>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, typeof(TestTypedSchema)), new((int)HttpStatusCode.BadRequest, typeof(ProblemDetails)), new((int)HttpStatusCode.NotFound, null) } };
+        yield return new object[] { typeof(Task<Ok>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { new((int)HttpStatusCode.OK, null) } };
 
         // Common types we should ignore
-        yield return new object[]
+        yield return new object[] { typeof(IResult), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
+        yield return new object[] { typeof(IActionResult), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
+        yield return new object[] { typeof(ActionResult<TestTypedSchema>), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
+        yield return new object[] { typeof(TestTypedSchema), new List<ExtractSchemaTypeResultFilter.ResponseMetadata> { } };
+    }
+
+    public static IEnumerable<object[]> GetAttributesData()
+    {
+        var methodsAndExpectedCodes = new Dictionary<string, HashSet<int>>
         {
-            typeof(IResult),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
+            { "WithOneProducesResponse", [200] },
+            { "WithTwoProducesResponse", [200, 404] },
+            { "WithProducesResponseWithType", [200, 404] },
+            { "WithProducesResponseWithSwaggerResponse", [200, 400, 404] }
         };
-        yield return new object[]
+
+        foreach (var pair in methodsAndExpectedCodes)
         {
-            typeof(IActionResult),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
-        };
-        yield return new object[]
-        {
-            typeof(ActionResult<TestTypedSchema>),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
-        };
-        yield return new object[]
-        {
-            typeof(TestTypedSchema),
-            new List<ExtractSchemaTypeResultFilter.ResponseMetadata> {}
-        };
+            var attributes = typeof(AnnotationTestClass).GetMethod(pair.Key)?.CustomAttributes;
+            if (attributes != null)
+            {
+                yield return new object[] { attributes, pair.Value };
+            }
+        }
     }
 
     [Theory]
-    [MemberData(nameof(GetData))]
+    [MemberData(nameof(GetResponseMetadataData))]
     internal void GetResponsesMetadata_ReturnsCorrectMetadata_ForTypedResultControllerMethods(Type returnType, IList<ExtractSchemaTypeResultFilter.ResponseMetadata> expectedMetadata)
     {
-
         // Act
         var responsesMetadata = ExtractSchemaTypeResultFilter.GetResponsesMetadata(returnType).ToList();
 
@@ -116,8 +67,46 @@ public class ExtractSchemaTypeResultFilterTests
         }
     }
 
+    [Theory]
+    [MemberData(nameof(GetAttributesData))]
+    internal void ExtractResponseCodesFromAttributes_ReturnsCorrectHashSet(IEnumerable<CustomAttributeData> endpointAttributes, HashSet<int> expectedResponseCodes)
+    {
+        // Act
+        var actualResponsesCodes = ExtractSchemaTypeResultFilter.ExtractResponseCodesFromAttributes(endpointAttributes);
+
+        // Assert
+        Assert.Equal(actualResponsesCodes, expectedResponseCodes);
+    }
+
     private sealed class TestTypedSchema
     {
         public int Count { get; set; }
+    }
+
+    private sealed class AnnotationTestClass
+    {
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public void WithOneProducesResponse()
+        {
+        }
+
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public void WithTwoProducesResponse()
+        {
+        }
+
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+        public void WithProducesResponseWithType()
+        {
+        }
+
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+        public void WithProducesResponseWithSwaggerResponse()
+        {
+        }
     }
 }

--- a/src/Workleap.Extensions.OpenAPI.Tests/Workleap.Extensions.OpenAPI.Tests.csproj
+++ b/src/Workleap.Extensions.OpenAPI.Tests/Workleap.Extensions.OpenAPI.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.Extensions.OpenAPI/TypedResult/ExtractSchemaTypeResultFilter.cs
+++ b/src/Workleap.Extensions.OpenAPI/TypedResult/ExtractSchemaTypeResultFilter.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using static System.Int32;
 
 namespace Workleap.Extensions.OpenAPI.TypedResult;
 
@@ -163,7 +162,7 @@ internal sealed class ExtractSchemaTypeResultFilter : IOperationFilter
 
         foreach (var response in operation.Responses)
         {
-            if (responseCodes.Contains(Parse(response.Key)))
+            if (responseCodes.Contains(int.Parse(response.Key)))
             {
                 continue;
             }

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
@@ -142,4 +142,31 @@ public class TypedResultController : ControllerBase
             _ => TypedResults.Ok(new TypedResultExample("Example"))
         };
     }
+
+    [HttpGet]
+    [Route("/validateOkNotPresent")]
+    public Results<Created<TypedResultExample>, Forbidden<string>, InternalServerError<string>> TypedResultWithOutOk(int id)
+    {
+        return id switch
+        {
+            0 => TypedResultsExtensions.Forbidden("Forbidden"),
+            < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
+            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example"))
+        };
+    }
+
+    [HttpGet]
+    [Route("/validateOkNotPresentButAnnotationPresent")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status202Accepted, Type = typeof(string))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, Type = typeof(string))]
+    public Results<Created<TypedResultExample>, Forbidden<string>, InternalServerError<string>> TypedResultWithoutOkButAnnotationPresent(int id)
+    {
+        return id switch
+        {
+            0 => TypedResultsExtensions.Forbidden("Forbidden"),
+            < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
+            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example"))
+        };
+    }
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
+++ b/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.7.0">
+    <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/tests/WebApi.OpenAPI.SystemTest/custom.spectral.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/custom.spectral.yaml
@@ -1,5 +1,4 @@
 extends: [https://raw.githubusercontent.com/gsoft-inc/wl-api-guidelines/main/.spectral.yaml]
 rules:
-  application-json-response-must-not-be-type-string: false
   must-return-content-types: false
   operation-operationId: false

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -320,8 +320,6 @@ paths:
             type: integer
             format: int32
       responses:
-        '200':
-          description: Success
         '204':
           description: '204'
         '401':
@@ -391,6 +389,82 @@ paths:
       responses:
         '200':
           description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          description: '500'
+          content:
+            application/json:
+              schema:
+                type: string
+  /validateOkNotPresent:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithOutOk
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '201':
+          description: '201'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          description: '500'
+          content:
+            application/json:
+              schema:
+                type: string
+  /validateOkNotPresentButAnnotationPresent:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithoutOkButAnnotationPresent
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Success
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        '201':
+          description: '201'
           content:
             application/json:
               schema:

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -320,8 +320,6 @@ paths:
             type: integer
             format: int32
       responses:
-        '200':
-          description: Success
         '204':
           description: '204'
         '401':
@@ -391,6 +389,82 @@ paths:
       responses:
         '200':
           description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          description: '500'
+          content:
+            application/json:
+              schema:
+                type: string
+  /validateOkNotPresent:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithOutOk
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '201':
+          description: '201'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '403':
+          description: '403'
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          description: '500'
+          content:
+            application/json:
+              schema:
+                type: string
+  /validateOkNotPresentButAnnotationPresent:
+    get:
+      tags:
+        - TypedResult
+      operationId: TypedResultWithoutOkButAnnotationPresent
+      parameters:
+        - name: id
+          in: query
+          style: form
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Success
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        '201':
+          description: '201'
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Description of changes
OpenAPI generation adds a default 200 status code even if it is not explicitly defined in the code. This PR removes the 200 status code if it is not part of the TypedResults or annotations.

## Breaking changes
There may be 200 responses that are removed going foward (which breaks the OpenAPI spec)

## Additional checks
Run system tests.

- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes