### PR TITLE
[IDP-1588] Support Named arguments in Annotation for Type mismatch rule

### DIFF
--- a/src/Workleap.Extensions.OpenAPI.Analyzers/CompareTypedResultWithAnnotationAnalyzer.cs
+++ b/src/Workleap.Extensions.OpenAPI.Analyzers/CompareTypedResultWithAnnotationAnalyzer.cs
@@ -148,7 +148,7 @@ public class CompareTypedResultWithAnnotationAnalyzer : DiagnosticAnalyzer
                 {
                     return;
                 }
-                
+
                 if (attribute.ConstructorArguments.Length == 1)
                 {
                     if (attribute.ConstructorArguments[0].Value is int statusCodeValue)
@@ -180,12 +180,12 @@ public class CompareTypedResultWithAnnotationAnalyzer : DiagnosticAnalyzer
                 {
                     return;
                 }
-                
+
                 if (attribute.ConstructorArguments.Length > 2 && attribute.ConstructorArguments[0].Value is int statusCodeValue)
                 {
                     if (attribute.ConstructorArguments[2].Value is ITypeSymbol typeFromAnnotation)
                     {
-                        ValidateAnnotationForTypeMismatch(attribute, statusCodeValue, typeFromAnnotation, methodSignatureStatusCodeToTypeMap, context);    
+                        ValidateAnnotationForTypeMismatch(attribute, statusCodeValue, typeFromAnnotation, methodSignatureStatusCodeToTypeMap, context);
                     }
                     else if (this._statusCodeToResultsMap.TryGetValue(statusCodeValue, out var type))
                     {

--- a/src/Workleap.Extensions.OpenAPI.Analyzers/CompareTypedResultWithAnnotationAnalyzer.cs
+++ b/src/Workleap.Extensions.OpenAPI.Analyzers/CompareTypedResultWithAnnotationAnalyzer.cs
@@ -136,7 +136,7 @@ public class CompareTypedResultWithAnnotationAnalyzer : DiagnosticAnalyzer
         private void ValidateAnnotationWithTypedResult(SymbolAnalysisContext context, AttributeData attribute,
             Dictionary<int, List<ITypeSymbol>> methodSignatureStatusCodeToTypeMap)
         {
-            if (attribute.AttributeClass == null || attribute.ConstructorArguments.Length == 0 && attribute.NamedArguments.Length == 0)
+            if (attribute.AttributeClass == null || (attribute.ConstructorArguments.Length == 0 && attribute.NamedArguments.Length == 0))
             {
                 return;
             }

--- a/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/BaseAnalyzerTest.cs
+++ b/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/BaseAnalyzerTest.cs
@@ -51,7 +51,7 @@ public class BaseAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVe
     // Specify the language version and that diagnostics should be reported for missing documentation.
     protected override ParseOptions CreateParseOptions()
     {
-        return new CSharpParseOptions(LanguageVersion.CSharp11, DocumentationMode.Diagnose);
+        return new CSharpParseOptions(LanguageVersion.CSharp12, DocumentationMode.Diagnose);
     }
 
     protected BaseAnalyzerTest<TAnalyzer> WithSourceCode(string sourceCode)

--- a/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/CompareTypedResultWithAnnotationAnalyzerTests.cs
+++ b/src/tests/Workleap.Extensions.OpenAPI.Analyzers.Tests/CompareTypedResultWithAnnotationAnalyzerTests.cs
@@ -265,4 +265,80 @@ public class CompareTypedResultWithAnnotationAnalyzerTests : BaseAnalyzerTest<Co
         await this.WithSourceCode(source)
             .RunAsync();
     }
+
+    [Fact]
+    public async Task Given_ProducesResponseNamedArgumentsAndCorrectTypedResults_When_Analyze_Then_No_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                  [HttpGet]
+                                  [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+                                  [ProducesResponseType(statusCode: StatusCodes.Status202Accepted, type: typeof(string))]
+                                  [ProducesResponseType(StatusCodes.Status403Forbidden)]
+                                  public async Task<Results<Ok<string>, Accepted<string>, Forbidden>> GetSampleEndpoint() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task Given_ProducesResponseNamedArgumentsAndMismatchTypedResults_When_Analyze_Then_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                  [HttpGet]
+                                  [{|WLOAS001:ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))|}]
+                                  [{|WLOAS001:ProducesResponseType(statusCode: StatusCodes.Status202Accepted, type: typeof(string))|}]
+                                  [{|WLOAS001:ProducesResponseType(StatusCodes.Status403Forbidden)|}]
+                                  public async Task<Results<Ok<int>, Accepted, Forbidden<string>>> GetSampleEndpoint() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task Given_SwaggerResponseNamedArgumentsAndCorrectTypedResults_When_Analyze_Then_No_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                  [HttpGet]
+                                  [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
+                                  [SwaggerResponse(statusCode: StatusCodes.Status202Accepted, "Return string", Type = typeof(string))]
+                                  [SwaggerResponse(type: typeof(string), statusCode: StatusCodes.Status400BadRequest)]
+                                  [SwaggerResponse(StatusCodes.Status403Forbidden, "Returns string", ContentTypes = ["application/json"])]
+                                  [SwaggerResponse(StatusCodes.Status500InternalServerError, "Returns string", typeof(string), ContentTypes = ["application/json"])]
+                                  public async Task<Results<Ok<string>, Accepted<string>, BadRequest<string>, Forbidden, InternalServerError<string>>> GetSampleEndpoint() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task Given_SwaggerResponseNamedArgumentsAndMismatchTypedResults_When_Analyze_Then_No_Diagnostic()
+    {
+        const string source = """
+                              public class AnalyzersController : ControllerBase
+                              {
+                                  [HttpGet]
+                                  [{|WLOAS001:SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))|}]
+                                  [{|WLOAS001:SwaggerResponse(statusCode: StatusCodes.Status202Accepted, "Return string", Type = typeof(string))|}]
+                                  [{|WLOAS001:SwaggerResponse(type: typeof(string), statusCode: StatusCodes.Status400BadRequest)|}]
+                                  [{|WLOAS001:SwaggerResponse(StatusCodes.Status403Forbidden, "Returns string", ContentTypes = ["application/json"])|}]
+                                  [{|WLOAS001:SwaggerResponse(StatusCodes.Status500InternalServerError, "Returns string", typeof(string), ContentTypes = ["application/json"])|}]
+                                  public async Task<Results<Ok<int>, Accepted, BadRequest<int>, Forbidden<int>, InternalServerError>> GetSampleEndpoint() => throw null;
+                              }
+                              """;
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
 }


### PR DESCRIPTION
## Description of changes
Currently, our Roslyn analyzer for detecting type mismatch does not flag properly when Typed arguments are being used. This PR address that gap and corrects that behavior.

## Breaking changes
None

## Additional checks
Run tests

- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes