### PR TITLE
[IDP-1861] Add enum tests and config for TypedResults return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ public Ok<ProblemDetails> TypedResultWithProducesResponseTypeAnnotation()
 }
 ```
 
+### Note: TypedResults requires `Microsoft.AspNetCore.Http.Json.JsonOptions` to be configured
+
+TypedResults uses obtains the JsonOptions from `Microsoft.AspNetCore.Http.Json.JsonOptions`. If you are using IActionResult return types, typically, you would configure `Microsoft.AspNetCore.Mvc.JsonOptions` which also configure the JsonSerializerOptions for SwashBuckle. To use this library, you need to configure both JsonOptions. Here is a snippet of code demonstrating that:
+
+```cs
+// API Extension methods
+
+// SwashBuckle and TypedResults require different JsonOptions to be configured.
+// https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2293
+public static IServiceCollection ConfigureJsonSerializerOptions(this IServiceCollection services)
+{
+    services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options => ConfigureJsonOptions(options.SerializerOptions));
+    services.Configure<Microsoft.AspNetCore.Mvc.JsonOptions>(options => ConfigureJsonOptions(options.JsonSerializerOptions));
+
+    return services;
+}
+
+private static void ConfigureJsonOptions(JsonSerializerOptions options)
+{
+    options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+    options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
+    options.WriteIndented = true;
+    options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    options.Converters.Add(new JsonStringEnumConverter());
+}
+```
+
+
 ## Included Roslyn analyzers
 
 | Rule ID | Category | Severity | Description                                                        |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ private static void ConfigureJsonOptions(JsonSerializerOptions options)
 {
     options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
     options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
-    options.WriteIndented = true;
     options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
     options.Converters.Add(new JsonStringEnumConverter());
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/Extensions/ApiExtensions.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/Extensions/ApiExtensions.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WebApi.OpenAPI.SystemTest.Extensions;
+
+public static class ApiExtensions
+{
+    public static void ConfigureControllers(this IServiceCollection services)
+    {
+        services.AddControllers();
+        services.ConfigureJsonSerializerOptions();
+    }
+
+    // SwashBuckle and TypedResults require different JsonOptions to be configured.
+    // https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2293
+    private static IServiceCollection ConfigureJsonSerializerOptions(this IServiceCollection services)
+    {
+        services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options => ConfigureJsonOptions(options.SerializerOptions));
+        services.Configure<Microsoft.AspNetCore.Mvc.JsonOptions>(options => ConfigureJsonOptions(options.JsonSerializerOptions));
+
+        return services;
+    }
+
+    private static void ConfigureJsonOptions(JsonSerializerOptions options)
+    {
+        options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
+        options.WriteIndented = true;
+        options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        options.Converters.Add(new JsonStringEnumConverter());
+    }
+}

--- a/src/tests/WebApi.OpenAPI.SystemTest/Extensions/ApiExtensions.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/Extensions/ApiExtensions.cs
@@ -25,7 +25,6 @@ public static class ApiExtensions
     {
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
-        options.WriteIndented = true;
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         options.Converters.Add(new JsonStringEnumConverter());
     }

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
@@ -127,7 +127,7 @@ public class TypedResultController : ControllerBase
         {
             0 => TypedResultsExtensions.Forbidden(),
             < 0 => TypedResultsExtensions.InternalServerError(),
-            _ => TypedResults.Ok(new TypedResultExample("Example"))
+            _ => TypedResults.Ok(new TypedResultExample("Example", OperationEnum.GetNotOperationId))
         };
     }
 
@@ -151,7 +151,7 @@ public class TypedResultController : ControllerBase
         {
             0 => TypedResultsExtensions.Forbidden("Forbidden"),
             < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
-            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example"))
+            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example", OperationEnum.GetExplicitOperationIdInSwagger))
         };
     }
 
@@ -166,7 +166,7 @@ public class TypedResultController : ControllerBase
         {
             0 => TypedResultsExtensions.Forbidden("Forbidden"),
             < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
-            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example"))
+            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example", OperationEnum.GetExplicitOperationIdInName))
         };
     }
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultController.cs
@@ -127,7 +127,7 @@ public class TypedResultController : ControllerBase
         {
             0 => TypedResultsExtensions.Forbidden(),
             < 0 => TypedResultsExtensions.InternalServerError(),
-            _ => TypedResults.Ok(new TypedResultExample("Example", OperationEnum.GetNotOperationId))
+            _ => TypedResults.Ok(new TypedResultExample("Example", OperationEnum.Foo))
         };
     }
 
@@ -151,7 +151,7 @@ public class TypedResultController : ControllerBase
         {
             0 => TypedResultsExtensions.Forbidden("Forbidden"),
             < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
-            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example", OperationEnum.GetExplicitOperationIdInSwagger))
+            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example", OperationEnum.Bar))
         };
     }
 
@@ -166,7 +166,7 @@ public class TypedResultController : ControllerBase
         {
             0 => TypedResultsExtensions.Forbidden("Forbidden"),
             < 0 => TypedResultsExtensions.InternalServerError("An error occured when processing the request."),
-            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example", OperationEnum.GetExplicitOperationIdInName))
+            _ => TypedResults.Created("hardcoded uri", new TypedResultExample("Example", OperationEnum.Foobar))
         };
     }
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultExample.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultExample.cs
@@ -7,9 +7,24 @@ public class TypedResultExample
         this.Name = name;
     }
 
+    public TypedResultExample(string name, OperationEnum operation)
+    {
+        this.Name = name;
+        this.Operation = operation;
+    }
+
     public string Name { get; set; }
 
     public int Count { get; set; }
 
     public string? Description { get; set; }
+
+    public OperationEnum Operation { get; set; }
+}
+
+public enum OperationEnum
+{
+    GetExplicitOperationIdInName,
+    GetExplicitOperationIdInSwagger,
+    GetNotOperationId
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultExample.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/ExtractTypeResult/TypedResultExample.cs
@@ -24,7 +24,7 @@ public class TypedResultExample
 
 public enum OperationEnum
 {
-    GetExplicitOperationIdInName,
-    GetExplicitOperationIdInSwagger,
-    GetNotOperationId
+    Foo,
+    Bar,
+    Foobar
 }

--- a/src/tests/WebApi.OpenAPI.SystemTest/Program.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/Program.cs
@@ -1,11 +1,12 @@
 using WebApi.OpenAPI.SystemTest;
+using WebApi.OpenAPI.SystemTest.Extensions;
 using WebApi.OpenAPI.SystemTest.ExtractTypeResult;
 using WebApi.OpenAPI.SystemTest.OperationId;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
-
+builder.Services.ConfigureControllers();
 builder.Services.AddSwagger();
 
 var app = builder.Build();

--- a/src/tests/WebApi.OpenAPI.SystemTest/Program.cs
+++ b/src/tests/WebApi.OpenAPI.SystemTest/Program.cs
@@ -5,7 +5,6 @@ using WebApi.OpenAPI.SystemTest.OperationId;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
 builder.Services.ConfigureControllers();
 builder.Services.AddSwagger();
 

--- a/src/tests/WebApi.OpenAPI.SystemTest/Properties/launchSettings.json
+++ b/src/tests/WebApi.OpenAPI.SystemTest/Properties/launchSettings.json
@@ -13,6 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5241",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
+++ b/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
@@ -23,7 +23,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>
+<!--    <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>-->
+    <OpenApiServiceProfile>frontend</OpenApiServiceProfile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
+++ b/src/tests/WebApi.OpenAPI.SystemTest/WebApi.OpenAPI.SystemTest.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-<!--    <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>-->
+   <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>
     <OpenApiServiceProfile>frontend</OpenApiServiceProfile>
   </PropertyGroup>
 

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -494,6 +494,12 @@ paths:
                 type: string
 components:
   schemas:
+    OperationEnum:
+      enum:
+        - GetExplicitOperationIdInName
+        - GetExplicitOperationIdInSwagger
+        - GetNotOperationId
+      type: string
     ProblemDetails:
       type: object
       properties:
@@ -614,6 +620,7 @@ components:
       required:
         - count
         - name
+        - operation
       type: object
       properties:
         name:
@@ -624,4 +631,6 @@ components:
         description:
           type: string
           nullable: true
+        operation:
+          $ref: '#/components/schemas/OperationEnum'
       additionalProperties: false

--- a/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.OpenAPI.SystemTest/openapi-v1.yaml
@@ -496,9 +496,9 @@ components:
   schemas:
     OperationEnum:
       enum:
-        - GetExplicitOperationIdInName
-        - GetExplicitOperationIdInSwagger
-        - GetNotOperationId
+        - Foo
+        - Bar
+        - Foobar
       type: string
     ProblemDetails:
       type: object

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -66,6 +66,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequiredExampleGrandParentClass'
+  '/minimal-endpoint-with-typed-result-no-produces/{id}':
+    get:
+      tags:
+        - TypedResult
+      operationId: GetMinimalApiWithTypedResultWithNoProduces
+      parameters:
+        - name: id
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypedResultExample'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
   /minimal-endpoint-with-typed-result-with-produces:
     get:
       tags:

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -66,34 +66,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequiredExampleGrandParentClass'
-  '/minimal-endpoint-with-typed-result-no-produces/{id}':
-    get:
-      tags:
-        - TypedResult
-      operationId: GetMinimalApiWithTypedResultWithNoProduces
-      parameters:
-        - name: id
-          in: path
-          required: true
-          style: simple
-          schema:
-            type: integer
-            format: int32
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TypedResultExample'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-        '404':
-          description: Not Found
   /minimal-endpoint-with-typed-result-with-produces:
     get:
       tags:
@@ -494,6 +466,12 @@ paths:
                 type: string
 components:
   schemas:
+    OperationEnum:
+      enum:
+        - GetExplicitOperationIdInName
+        - GetExplicitOperationIdInSwagger
+        - GetNotOperationId
+      type: string
     ProblemDetails:
       type: object
       properties:
@@ -614,6 +592,7 @@ components:
       required:
         - count
         - name
+        - operation
       type: object
       properties:
         name:
@@ -624,4 +603,6 @@ components:
         description:
           type: string
           nullable: true
+        operation:
+          $ref: '#/components/schemas/OperationEnum'
       additionalProperties: false

--- a/src/tests/expected-openapi-document.yaml
+++ b/src/tests/expected-openapi-document.yaml
@@ -496,9 +496,9 @@ components:
   schemas:
     OperationEnum:
       enum:
-        - GetExplicitOperationIdInName
-        - GetExplicitOperationIdInSwagger
-        - GetNotOperationId
+        - Foo
+        - Bar
+        - Foobar
       type: string
     ProblemDetails:
       type: object


### PR DESCRIPTION
## Description of changes
TypedResults do not use the same JsonOptions as IActionResult. Thus, we need to configure two JsonOptions at startup. Both 
`Microsoft.AspNetCore.Http.Json.JsonOptions` and `Microsoft.AspNetCore.Mvc.JsonOptions` need to be configured.

## Breaking changes
None, but users need to update their API extensions.

References:
https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2293

- [x] Updated the documentation of the project to reflect the changes: README update
- [x] Added new tests that cover the code changes Added system test case to cover this case. 