### PR TITLE
IDP-2085 - Add cortex descriptor file

### DIFF
--- a/.cortex/catalog/service-wl-extensions-openapi.yaml
+++ b/.cortex/catalog/service-wl-extensions-openapi.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+info:
+  title: Workleap Extensions OpenApi
+  x-cortex-git:
+    github:
+      alias: gsoft-inc
+      repository: gsoft-inc/wl-extensions-openapi
+  x-cortex-tag: service-wl-extensions-openapi
+  x-cortex-type: library
+  x-cortex-slack:
+    channels:
+    - name: internal-dev-platform
+      notificationsEnabled: true
+  x-cortex-owners:
+  - name: team-internal-developer-platform-backend
+    type: GROUP
+    provider: CORTEX
+  x-cortex-link:
+  - type: cortex
+    url: https://github.com/gsoft-inc/wl-extensions-openapi/blob/main/.cortex/catalog/service-wl-extensions-openapi.yaml
+    name: Edit current Cortex entity in GitHub
+


### PR DESCRIPTION
This PR adds the cortex descriptor file for this service. This is the file that Cortex will use to populate your service into the catalog.